### PR TITLE
Add pre-commit hooks configuration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+-   id: editorconfig-checker
+    name: editorconfig-checker
+    description: '`editorconfig-checker` is a tool to check if your files consider your .editorconfig-rules.'
+    entry: editorconfig-checker
+    language: python
+    types: [text]
+    require_serial: true

--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ USAGE:
         print the version number
 ```
 
+## Usage with the pre-commit git hooks framework
+
+editorconfig-checker can be included as a hook for [pre-commit](https://pre-commit.com/). The easiest way to get started is to add this configuration to your `.pre-commit-config.yaml`:
+
+```yaml
+repos:
+-   repo: https://github.com/editorconfig-checker/editorconfig-checker.python
+    rev: ''  # pick a git hash / tag to point to
+    hooks:
+    -   id: editorconfig-checker
+```
+
+See the [pre-commit docs](https://pre-commit.com/#pre-commit-configyaml---hooks) for how to customize this configuration.
+
 ## Run tests
 
 The test script uses `docker`. After installing it, you can run the test with:


### PR DESCRIPTION
This adds support for using this repo as pre-commit hook (https://pre-commit.com/). To add editorconfig-checker to your repository add this to your .pre-commit-config.yaml:

```yaml
repos:
-   repo: https://github.com/editorconfig-checker/editorconfig-checker.python
    rev: ''  # pick a git hash / tag to point to
    hooks:
    -   id: editorconfig-checker
```

pre-commit also supports building go packages directly from repository, however this would require go on the client. Since pre-commit is also written in Python, and thus no further dependency is produced, this wrapper is preferred instead. See https://github.com/editorconfig-checker/editorconfig-checker/issues/133 for details.

The use of `types: [text]` is debatable. If I understood the [documentation](https://pre-commit.com/#filtering-files-with-types) correctly, it filters files which are recognized by Git as text files before passing to editorconfig-checker. This is merely an optimization and can be overwritten by the user if necessary. However, if Git recognizes a file with the wrong type at might be silently ignored. @mstruebing opinions? Is this even necessary or would our just pass all files to editorconfig-checker?