### PR TITLE
Add system pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,15 @@
+---
 -   id: editorconfig-checker
-    name: editorconfig-checker
+    name: 'Check .editorconfig rules'
     description: '`editorconfig-checker` is a tool to check if your files consider your .editorconfig-rules.'
     entry: ec
     language: python
-    types: [text]
+    types: [ text ]
+    require_serial: true
+-   id: editorconfig-checker-system
+    name: 'Check .editorconfig rules'
+    description: 'Runs system executable of `editorconfig-checker` to lint text files according to `.editorconfig` rules'
+    language: system
+    entry: ec
+    types: [ text ]
     require_serial: true

--- a/README.md
+++ b/README.md
@@ -32,4 +32,19 @@ repos:
         alias: ec
 ```
 
+The above hook is a python wrapper that automatically downloads and installs
+[editorconfig-checker](https://editorconfig-checker.github.io/) binary.
+If you manage your tools in some other way, for example, via [ASDF](https://asdf-vm.com/),
+you may want to use an alternative pre-commit hook that assumes that
+`ec` binary executable is already available on the system path:
+
+```yaml
+repos:
+-   repo: https://github.com/editorconfig-checker/editorconfig-checker.python
+    rev: ''  # pick a git hash / tag to point to
+    hooks:
+    -   id: editorconfig-checker-system
+        alias: ec
+```
+
 See the [pre-commit docs](https://pre-commit.com/#pre-commit-configyaml---hooks) to check how to customize this configuration.


### PR DESCRIPTION
We manage our local developer tooling via [ASDF](https://asdf-vm.com/) and we would prefer a simpler pre-commit hook,
which would simply rely on the `ec` executable being in the `$PATH` instead of trying to download it.