### PR TITLE
Fix lack of .exe extension on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -93,6 +93,8 @@ def extract_tarball(url, data):
 
 def save_executables(data, base_dir):
     exe = EDITORCONFIG_CHECKER_EXE_NAME
+    if system() == 'Windows':
+        exe += '.exe'
 
     output_path = path.join(base_dir, exe)
     makedirs(base_dir)


### PR DESCRIPTION
Hi there!

2.6.x broke Windows support for us. The reason is that due to below change, the ec executable no longer gets the .exe extension on Windows after installation. As such it is not recognized as executable anymore and you cannot execute it from CLI.

Source of problematic change: https://github.com/editorconfig-checker/editorconfig-checker.python/pull/20#discussion_r966246818

![grafik](https://user-images.githubusercontent.com/116660745/197817986-3f600e8b-ab09-4de4-b166-7468ab11e886.png)

