### PR TITLE
Fix an error from setuptools that prevents pre-commit installation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ url = https://github.com/editorconfig-checker/editorconfig-checker.python
 author = Marco M.
 author_email = mmicu.github00@gmail.com
 license = MIT
-license_file = LICENSE
+license_files = LICENSE
 classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 2


### PR DESCRIPTION
setuptools no longer allows use of the `license_file` (singular) option.

When used as a pre-commit hook, pre-commit now throws an error that occurs because setuptools rejects the current `setup.cfg` file with this error message:

```
********************************************************************************
The license_file parameter is deprecated, use license_files instead.
      
By 2023-Oct-30, you need to update your project and remove deprecated calls
or your builds will no longer be supported.
      
See https://setuptools.pypa.io/en/latest/userguide/declarative_config.html for details.
********************************************************************************
```

This PR addresses this error by converting `license_file` (singular) to `license_files` (plural).