### PR TITLE
chore!: rename `ec` to `editorconfig-checker`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,15 +1,15 @@
 ---
--   id: editorconfig-checker
-    name: 'Check .editorconfig rules'
-    description: '`editorconfig-checker` is a tool to check if your files consider your .editorconfig-rules.'
-    entry: ec
-    language: python
-    types: [ text ]
-    require_serial: true
--   id: editorconfig-checker-system
-    name: 'Check .editorconfig rules'
-    description: 'Runs system executable of `editorconfig-checker` to lint text files according to `.editorconfig` rules'
-    language: system
-    entry: ec
-    types: [ text ]
-    require_serial: true
+- id: editorconfig-checker
+  name: "Check .editorconfig rules"
+  description: "`editorconfig-checker` is a tool to check if your files consider your .editorconfig-rules."
+  entry: editorconfig-checker
+  language: python
+  types: [text]
+  require_serial: true
+- id: editorconfig-checker-system
+  name: "Check .editorconfig rules"
+  description: "Runs system executable of `editorconfig-checker` to lint text files according to `.editorconfig` rules"
+  language: system
+  entry: editorconfig-checker
+  types: [text]
+  require_serial: true

--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Internally, this package provides a convenient way to download the pre-built `ed
 
 ## Usage
 
-After installation, the `ec` binary should be available in your environment (or `ec.exe` on Windows):
+After installation, the `editorconfig-checker` binary should be available in your environment (or `editorconfig-checker.exe` on Windows):
 
 ```
-ec -version
+editorconfig-checker -version
 ```
 
 ## Usage with the pre-commit git hooks framework
@@ -36,26 +36,26 @@ The easiest way to get started is to add this configuration to your `.pre-commit
 
 ```yaml
 repos:
--   repo: https://github.com/editorconfig-checker/editorconfig-checker.python
-    rev: ''  # pick a git hash / tag to point to
+  - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
+    rev: "" # pick a git hash / tag to point to
     hooks:
-    -   id: editorconfig-checker
-        alias: ec
+      - id: editorconfig-checker
+        alias: editorconfig-checker
 ```
 
 The above hook is a python wrapper that automatically downloads and installs
 [editorconfig-checker](https://editorconfig-checker.github.io/) binary.
 If you manage your tools in some other way, for example, via [ASDF](https://asdf-vm.com/),
 you may want to use an alternative pre-commit hook that assumes that
-`ec` binary executable is already available on the system path:
+`editorconfig-checker` binary executable is already available on the system path:
 
 ```yaml
 repos:
--   repo: https://github.com/editorconfig-checker/editorconfig-checker.python
-    rev: ''  # pick a git hash / tag to point to
+  - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
+    rev: "" # pick a git hash / tag to point to
     hooks:
-    -   id: editorconfig-checker-system
-        alias: ec
+      - id: editorconfig-checker-system
+        alias: editorconfig-checker
 ```
 
 See the [pre-commit docs](https://pre-commit.com/#pre-commit-configyaml---hooks) to check how to customize this configuration.

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -41,7 +41,7 @@ build_docker_image_and_run() {
     docker build -t "$docker_image" -f "$dockerfile" --no-cache --quiet .
 
     # Run `editorconfig-checker`
-    docker run --rm "$docker_image" ec -version
+    docker run --rm "$docker_image" editorconfig-checker -version
 }
 
 main() {

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ we decided to move the wrapper logic directly in the setup phase.
 During setup, the tarball that contains the executable will be downloaded based on
 the target machine and its content extracted in the proper output directory.
 
-Once the setup is complete, the `ec` executable should be available on your machine.
+Once the setup is complete, the `editorconfig-checker` executable should be available on your machine.
 """
 
 from distutils.command.build import build as orig_build
@@ -34,7 +34,7 @@ except ImportError:
 
 WRAPPER_VERSION = '3.0.3'
 EDITORCONFIG_CHECKER_CORE_VERSION = 'v3.0.3'
-EDITORCONFIG_CHECKER_EXE_NAME = 'ec'
+EDITORCONFIG_CHECKER_EXE_NAME = 'editorconfig-checker'
 
 
 def get_tarball_url():
@@ -57,10 +57,10 @@ def get_tarball_url():
             raise ValueError('Cannot determine architecture')
 
         # The core, from `2.7.0`, introduces the extension in the tarball name
-        # (e.g. `ec-windows-386.exe.tar.gz`, `ec-windows-arm.exe.tar.gz`)
+        # (e.g. `editorconfig-checker-windows-386.exe.tar.gz`, `editorconfig-checker-windows-arm.exe.tar.gz`)
         _ext = '.exe' if _system == 'Windows' else ''
 
-        return 'ec-{}-{}{}'.format(
+        return 'editorconfig-checker-{}-{}{}'.format(
             _system.lower(),
             _architecture,
             _ext,
@@ -91,7 +91,7 @@ def extract_tarball(url, data):
         if '.tar.' in url:
             with tarfile_open(fileobj=bio) as fp:
                 for info in fp.getmembers():
-                    if info.isfile() and info.name.startswith('bin/ec-'):
+                    if info.isfile() and info.name.startswith('bin/editorconfig-checker-'):
                         return fp.extractfile(info).read()
 
     raise AssertionError('unreachable `extract` function')


### PR DESCRIPTION
BREAKING CHANGE: `ec` alias no longer available.

Ref: https://github.com/editorconfig-checker/editorconfig-checker/pull/371